### PR TITLE
Fix Network Admin URL

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -46,7 +46,7 @@ define( 'WP_ALLOW_MULTISITE', true );
 define( 'MULTISITE', true );
 define( 'SUBDOMAIN_INSTALL', false );
 $base = '/';
-define( 'DOMAIN_CURRENT_SITE', str_replace( 'https://', '', getenv( 'DDEV_PRIMARY_URL' ) ) );
+define( 'DOMAIN_CURRENT_SITE', preg_replace( '/https?:\/\//', '', getenv( 'DDEV_PRIMARY_URL' ) ) );
 define( 'PATH_CURRENT_SITE', '/' );
 define( 'SITE_ID_CURRENT_SITE', 1 );
 define( 'BLOG_ID_CURRENT_SITE', 1 );


### PR DESCRIPTION
Handles `http://` or `https://` in `DDEV_PRIMARY_URL` when setting `DOMAIN_CURRENT_SITE`. This was causing trouble with the Network Admin.