### PR TITLE
Enable autoindex generation in nginx config.

### DIFF
--- a/.ddev/nginx_full/nginx-site.conf
+++ b/.ddev/nginx_full/nginx-site.conf
@@ -16,6 +16,10 @@ server {
 
     index index.php index.htm index.html;
 
+    # Enable _unsafe_ autoindexing, to allow replication of issues
+    # where this is a problem.
+    autoindex on;
+
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
     sendfile off;
     error_log /dev/stdout info;


### PR DESCRIPTION
This normally unsafe config option allows us to replicate issues with information disclosure due to not preventing directory listing access.