### PR TITLE
Add indexing to Apache config for testing

### DIFF
--- a/.ddev/apache/apache-site.conf
+++ b/.ddev/apache/apache-site.conf
@@ -1,0 +1,105 @@
+# ddev generic/default/php config for apache2
+
+# If you want to take over this file and customize it, remove the line above
+# and ddev will respect it and won't overwrite the file.
+# See https://ddev.readthedocs.io/en/stable/users/extend/customization-extendibility/#providing-custom-apache-configuration
+<VirtualHost *:80>
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond    %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule    ^(.+[^/])$           https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    <Directory "/var/www/html/">
+      # Enable _unsafe_ autoindexing, to allow replication of issues
+      # where this is a problem.
+      Options Indexes
+      AllowOverride All
+      Allow from All
+    </Directory>
+    # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+    # error, crit, alert, emerg.
+    # It is also possible to configure the loglevel for particular
+    # modules, e.g.
+    #LogLevel info ssl:warn
+
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    # For most configuration files from conf-available/, which are
+    # enabled or disabled at a global level, it is possible to
+    # include a line for only one particular virtual host. For example the
+    # following line enables the CGI configuration for this host only
+    # after it has been globally disabled with "a2disconf".
+    #Include conf-available/serve-cgi-bin.conf
+
+    # Increase allowed field size for large cookies header.
+    LimitRequestFieldSize 16380
+
+    # Simple ddev technique to get a phpstatus
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+    Alias "/xhprof" "/var/xhprof/xhprof_html"
+    <Directory "/var/xhprof">
+        Options Indexes
+        AllowOverride None
+        Require all granted
+    </Directory>
+
+</VirtualHost>
+
+<VirtualHost *:443>
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/master.crt
+    SSLCertificateKeyFile /etc/ssl/certs/master.key
+
+    # Workaround from https://mail-archives.apache.org/mod_mbox/httpd-users/201403.mbox/%3C49404A24C7FAD94BB7B45E86A9305F6214D04652@MSGEXSV21103.ent.wfb.bank.corp%3E
+    # See also https://gist.github.com/nurtext/b6ac07ac7d8c372bc8eb
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond    %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule    ^(.+[^/])$           https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    <Directory "/var/www/html/">
+      # Enable _unsafe_ autoindexing, to allow replication of issues
+      # where this is a problem.
+      Options Indexes
+      AllowOverride All
+      Allow from All
+    </Directory>
+    # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+    # error, crit, alert, emerg.
+    # It is also possible to configure the loglevel for particular
+    # modules, e.g.
+    #LogLevel info ssl:warn
+
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    # Increase allowed field size for large cookies header.
+    LimitRequestFieldSize 16380
+
+    # For most configuration files from conf-available/, which are
+    # enabled or disabled at a global level, it is possible to
+    # include a line for only one particular virtual host. For example the
+    # following line enables the CGI configuration for this host only
+    # after it has been globally disabled with "a2disconf".
+    #Include conf-available/serve-cgi-bin.conf
+    # Simple ddev technique to get a phpstatus
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+    Alias "/xhprof" "/var/xhprof/xhprof_html"
+    <Directory "/var/xhprof">
+        Options Indexes
+        AllowOverride None
+        Require all granted
+    </Directory>
+
+</VirtualHost>
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
This matches our `nginx` config by adding directory indexing. This is a good testing setup for cases involving sensitive files with unpredictable names but in predicably-named directories.

Note that we hadn't previously done any changes to the Apache config, so this PR adds the full config. The additions are on lines 17-19 and 71-73.