### PR TITLE
Add nginx rewrites for subdirectory multisite

### DIFF
--- a/.ddev/nginx_full/nginx-site.conf
+++ b/.ddev/nginx_full/nginx-site.conf
@@ -2,6 +2,7 @@
 
 # Differences from the autgenerated ddev config:
 # - Allow requests to php files in uploads and files directories.
+# - Add the rewrites WordPress requires for subdirectory multisite.
 
 server {
     listen 80 default_server;
@@ -43,6 +44,18 @@ server {
     # Keep logging the requests to parse later (or to pass to firewall utilities such as fail2ban)
     location ~ /\. {
         deny all;
+    }
+
+    # WordPress subdirectory-multisite rewrites, the nginx equivalent of the
+    # .htaccess rules WordPress prints at Tools > Network Setup.
+    # The bench installs multisite by default (wp-config.php sets MULTISITE
+    # with SUBDOMAIN_INSTALL false), so without these every request under a
+    # subsite path, /<subsite>/wp-admin/ and /<subsite>/wp-login.php included,
+    # 404s and only the main site is reachable.
+    if (!-e $request_filename) {
+        rewrite /wp-admin$ $scheme://$host$uri/ permanent;
+        rewrite ^(/[^/]+)?(/wp-.*) $2 last;
+        rewrite ^(/[^/]+)?(/.*\.php) $2 last;
     }
 
     location / {


### PR DESCRIPTION
## Problem

The bench installs WordPress **multisite by default** — `wp-config.php` sets
`MULTISITE` with `SUBDOMAIN_INSTALL` false, and `config.yaml` runs
`wp core multisite-install` — but `nginx-site.conf` carried none of the rewrites
WordPress requires for subdirectory multisite.

The result is that only the main site is reachable. Every request under a subsite
path 404s, including `/<subsite>/wp-admin/` and `/<subsite>/wp-login.php`.

That makes it impossible to reproduce any finding whose attacker is a **subsite
user**, which is the entire multisite tenant-separation class (subsite admin vs
network super admin). The bench advertises multisite as a feature, so this is a
silent gap rather than a missing extra: you only discover it mid-validation.

## Fix

Add the nginx equivalent of the `.htaccess` rules WordPress prints at
**Tools > Network Setup**.

## Scope

Only the nginx config is changed. `.ddev/apache/apache-site.conf` is still DDEV's
untouched generated default, and `webserver_type` is unset, so nginx-fpm is what
actually serves the bench.

## Verification

The rewrite block was confirmed working live in a running bench container while
validating a multisite subsite-admin finding: before the change
`/<subsite>/wp-admin/*` returned 404, after it the subsite admin screens loaded
and role-scoped requests behaved correctly. It has **not** been re-tested from a
fresh `ddev start`, so that's worth a sanity check before merge.