### PR TITLE
Restore FollowSymLinks so .htaccess RewriteRules work under Apache

### DIFF
--- a/.ddev/apache/apache-site.conf
+++ b/.ddev/apache/apache-site.conf
@@ -16,7 +16,11 @@
     <Directory "/var/www/html/">
       # Enable _unsafe_ autoindexing, to allow replication of issues
       # where this is a problem.
-      Options Indexes
+      # FollowSymLinks is required for mod_rewrite to honour a RewriteRule in
+      # .htaccess. Apache's Options directive REPLACES the inherited set unless
+      # each value is prefixed with + or -, so it must be listed alongside
+      # Indexes here, not left to the default.
+      Options Indexes FollowSymLinks
       AllowOverride All
       Allow from All
     </Directory>
@@ -70,7 +74,11 @@
     <Directory "/var/www/html/">
       # Enable _unsafe_ autoindexing, to allow replication of issues
       # where this is a problem.
-      Options Indexes
+      # FollowSymLinks is required for mod_rewrite to honour a RewriteRule in
+      # .htaccess. Apache's Options directive REPLACES the inherited set unless
+      # each value is prefixed with + or -, so it must be listed alongside
+      # Indexes here, not left to the default.
+      Options Indexes FollowSymLinks
       AllowOverride All
       Allow from All
     </Directory>


### PR DESCRIPTION
The <Directory "/var/www/html/"> blocks set `Options Indexes` to enable autoindexing for reproducing directory-listing issues. Apache's Options directive replaces the inherited set unless every value is prefixed with
+ or -, so adding Indexes on its own silently dropped FollowSymLinks.

mod_rewrite refuses a RewriteRule in .htaccess without FollowSymLinks or SymLinksIfOwnerMatch, so with webserver_type: apache-fpm every rewrite is rejected:

  AH00670: Options FollowSymLinks and SymLinksIfOwnerMatch are both off,
  so the RewriteRule directive is also forbidden due to its similar
  ability to circumvent directory restrictions

The failure presents as a plain 403 on any pretty permalink rather than as a configuration error, so it reads as "the plugin does not reproduce" rather than as a broken bench. That is expensive for any finding that depends on rewrites, page-cache plugins in particular, since those serve their cache through an .htaccess block and never exercise the serve path at all without it.

Verified on this branch with webserver_type: apache-fpm, toggling only this directive:

  Options Indexes FollowSymLinks   ->  200  (post renders)
  Options Indexes                  ->  403
  Options Indexes FollowSymLinks   ->  200

Autoindexing is unaffected: /wp-content/uploads/ still returns a listing. The /var/xhprof blocks are left alone, since they are AllowOverride None and serve no .htaccess.